### PR TITLE
Changed deprecated gulp.run to recommended replacement

### DIFF
--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -35,6 +35,4 @@ gulp.task('url', function(){
 });
 
 
-gulp.task('default', function(){
-  gulp.run('simple', 'template', 'open', 'url', 'stream');
-});
+gulp.task('default', ['simple', 'template', 'open', 'url', 'stream']);


### PR DESCRIPTION
Since gulp version 3.5 the gulp.run has been deprecated. See the [changelog](https://github.com/gulpjs/gulp/blob/master/CHANGELOG.md#35).

This pull request fixes this in `examples/gulpfile.js`.
