### PR TITLE
Edited run example because of deprecated gulp.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ gulp.task("url", function(){
 
 // Run the task with gulp
 
-gulp.task("default", function(){
-  gulp.run("open");
-});
+gulp.task("default", ["open"]);
 ```
 ####You can view more examples in the [example folder.](https://github.com/stevelacy/gulp-open/tree/master/examples)
 


### PR DESCRIPTION
For a better explanation read [this comment](https://github.com/stevelacy/gulp-open/pull/10#issuecomment-60004673).
