### PR TITLE
Feature/new architecture proposal

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,19 @@
+{
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "indent": 2,
+  "newcap": false,
+  "quotmark": "single",
+  "maxdepth": 5,
+  "maxstatements": 50,
+  "maxlen": 100,
+  "eqnull": true,
+  "funcscope": true,
+  "strict": true,
+  "undef": true,
+  "unused": true,
+  "node": true,
+  "mocha": true
+}

--- a/README.md
+++ b/README.md
@@ -47,19 +47,22 @@ var browser = os.platform() === 'linux' ? 'google-chrome' : (
   os.platform() === 'darwin' ? 'google chrome' : (
   os.platform() === 'win32' ? 'chrome' : 'firefox'));
 
+gulp.src("./package.json").pipe(open({}, {app: chrome}));
+
 gulp.task('file-browser', function(){
   gulp.src('./htdocs/*.html')
-  .pipe(open({app: browser}));
+  .pipe(open({}, {app: browser}));
 });
 
 // Simple usage, no options.
 // This will use the url in the default browser
+// Note that we need to provide "__filename" to `src` and
+// an empty object to open.
 
 gulp.task('url', function(){
-  gulp.src([])
-  .pipe(open({uri: http://www.google.com}));
+  gulp.src(__filename)
+  .pipe(open({}, {uri: http://www.google.com}));
 });
-
 
 // Open an URL in a given browser:
 
@@ -68,8 +71,8 @@ gulp.task('url', function(){
     uri: 'http://localhost:3000',
     app: 'firefox'
   };
-  gulp.src([])
-  .pipe(open(options));
+  gulp.src(__filename)
+  .pipe(open({}, options));
 });
 
 // Run the task with gulp

--- a/README.md
+++ b/README.md
@@ -39,41 +39,38 @@ var open = require('gulp-open');
 
 gulp.task('default', function(){
   gulp.src('./index.html')
-  .pipe(open('<%file.path%>'));
-});
-
-
-// Open all .html files in a folder with a defined application
-
-gulp.task('open', function(){
-  gulp.src('./htdocs/*.html')
-  .pipe(open('<%file.path%>', {app: 'google-chrome'}));
-});
-
-
-// Simple usage, no options.
-// This will use the default applications
-
-gulp.task('simple', function(){
-  gulp.src('./index.html')
   .pipe(open());
 });
 
+// Open all .html files in a folder with a browser
+var browser = os.platform() === 'linux' ? 'google-chrome' : (
+  os.platform() === 'darwin' ? 'google chrome' : (
+  os.platform() === 'win32' ? 'chrome' : 'firefox'));
 
-// Open an URL:
+gulp.task('file-browser', function(){
+  gulp.src('./htdocs/*.html')
+  .pipe(open({app: browser}));
+});
+
+// Simple usage, no options.
+// This will use the url in the default browser
+
+gulp.task('url', function(){
+  gulp.src([])
+  .pipe(open({uri: http://www.google.com}));
+});
+
+
+// Open an URL in a given browser:
 
 gulp.task('url', function(){
   var options = {
-    url: 'http://localhost:3000',
+    uri: 'http://localhost:3000',
     app: 'firefox'
   };
-  gulp.src('./index.html')
-  .pipe(open('', options));
+  gulp.src([])
+  .pipe(open(options));
 });
-// A file must be specified as the src when running options.url or gulp will overlook the task.
-
-
-
 
 // Run the task with gulp
 
@@ -83,24 +80,9 @@ gulp.task('default', ['open']);
 
 
 ##Options
-`Object, {app, url}`
+`Object, {app, uri}`
 
-`.pipe(open(Template, options))`
-
-###Template (Required to use options)
-`String, file.path`
-
-```javascript
-
-<%file.path%>
-
-// Example:
-.pipe(open('<%file.path%>'));
-
-.pipe(open('file:// <%= file.path%>', {app: 'google-chrome'}));
-
-```
-
+`.pipe(open(options))`
 
 ###Options.app
 `String, local application`
@@ -116,30 +98,27 @@ NOTE: If the ``options.app`` is not defined, the Default application will be use
 
 // Example:
 
-.pipe(open('file://<%file.path%>', {app: 'google-chrome'}));
+.pipe(open({uri: 'file:///etc/resolv.conf', app: 'google-chrome'}));
 
 ```
-###Options.url
-`String, web url`
+###Options.uri
+`String, any valid uri (url, file protocol, or full path)`
 
 ####Note for windows users:
 URLs may not have a default application. If the task is running without opening in a browser try setting the options.app.
 Google Chrome: "chrome"
 Firefox: "firefox"
 
+If the uri provided is a file, a sync verification is performed by this plugin to verify that the file exists.
+
 ```javascript
 
 'http://localhost:3000'
 
 // Example:
-gulp.src('./stubFile.html')
-.pipe(open('', {app: 'google-chrome', url: 'http://localhost:3000'}));
-// An actual file must be specified as the src when running options.url or gulp-open es.map will overlook the task.
+gulp.src([])
+.pipe(open({app: 'google-chrome', uri: 'http://localhost:3000'}));
 ```
-
-
-
-
 ## LICENSE
 
 (MIT License)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var gutil = require('gulp-util');
 
 var log = gutil.log;
 var colors = gutil.colors;
-var PluginError = gutil.PluginError;
 
 var PLUGIN_NAME = 'gulp-open';
 
@@ -16,16 +15,16 @@ var ACCEPTABLE_URI_FORMATS = ['/', 'file://', 'http://', 'https://'];
 module.exports = function(src, opt) {
 
   opt = opt || {};
-  var plugInErrors = [];
+  var initError = null;
   if (!src && !opt.uri) {
-    plugInErrors.push(new PluginError(PLUGIN_NAME, 'URI is missing or incorrect! Use the ' +
-      'src or the options to indicate a uri ' + ACCEPTABLE_URI_FORMATS));
+    initError = 'URI is missing or incorrect! Use the src or the options to indicate a uri' +
+      ACCEPTABLE_URI_FORMATS;
   }
 
   return through.obj(function(file, enc, cb) {
 
-    if (plugInErrors.length > 0) {
-      cb(null, plugInErrors[0]);
+    if (initError) {
+      return cb(new gutil.PluginError(PLUGIN_NAME, initError));
     }
     if (file.isNull()) {
       return cb(null, file); // pass along
@@ -36,16 +35,14 @@ module.exports = function(src, opt) {
 
     var selectedType = 'none';
     // If the uri was not passed either by the stream nor by the options
-    if (plugInErrors.length === 0) {
-      var indexOfAnyFormat = _getIndexesOfAcceptableFormats(opt.uri);
-      if (indexOfAnyFormat === -1) {
-        plugInErrors.push(new PluginError(PLUGIN_NAME, 'URI is missing or incorrect! Please ' +
-          'use one of ' + ACCEPTABLE_URI_FORMATS));
+    var indexOfAnyFormat = _getIndexesOfAcceptableFormats(opt.uri);
+    if (indexOfAnyFormat === -1) {
+      return cb(new gutil.PluginError(PLUGIN_NAME, 'URI is missing or incorrect! Please ' +
+        'use one of ' + ACCEPTABLE_URI_FORMATS));
 
-      } else {
-        // If the type is the index value in the range of files
-        selectedType = indexOfAnyFormat <= 1 ? 'file' : 'url';
-      }
+    } else {
+      // If the type is the index value in the range of files
+      selectedType = indexOfAnyFormat <= 1 ? 'file' : 'url';
     }
 
     if (opt.app) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-var es = require('event-stream');
-var fs = require('fs');
+'use strict';
+
 var open = require('open');
+var through = require('through2');
 var gutil = require('gulp-util');
 
 var log = gutil.log;
@@ -10,89 +11,68 @@ var PluginError = gutil.PluginError;
 var PLUGIN_NAME = 'gulp-open';
 
 // The acceptable uri formats for opening
-var ACCEPTABLE_URI_FORMATS = ["/", "file://", "http://", "https://"];
+var ACCEPTABLE_URI_FORMATS = ['/', 'file://', 'http://', 'https://'];
 
-// Main plugin
-var gulpOpen = function(opt) {
+module.exports = function(src, opt) {
 
-  var stream;
   opt = opt || {};
+  var plugInErrors = [];
+  if (!src && !opt.uri) {
+    plugInErrors.push(new PluginError(PLUGIN_NAME, 'URI is missing or incorrect! Use the ' +
+      'src or the options to indicate a uri ' + ACCEPTABLE_URI_FORMATS));
+  }
 
-  // Executes the opening based on a given uri
-  var executeOpening = function() {
-    if (!opt.uri) {
-      stream.emit("error", new PluginError(PLUGIN_NAME, "URI is missing or incorrect! Use the src or the " + 
-        "options to indicate a uri " + ACCEPTABLE_URI_FORMATS));
+  return through.obj(function(file, enc, cb) {
+
+    if (plugInErrors.length > 0) {
+      cb(null, plugInErrors[0]);
+    }
+    if (file.isNull()) {
+      return cb(null, file); // pass along
+    }
+    if (file.path)  {
+      opt.uri = file.path;
     }
 
+    var selectedType = 'none';
     // If the uri was not passed either by the stream nor by the options
-    var indexOfIndexOf = _indexOfIndexOf(opt.uri);
-    if (indexOfIndexOf === -1) {
-      stream.emit("error", new PluginError(PLUGIN_NAME, "URI is missing or incorrect! Please use one of " + ACCEPTABLE_URI_FORMATS));
-    }
+    if (plugInErrors.length === 0) {
+      var indexOfAnyFormat = _getIndexesOfAcceptableFormats(opt.uri);
+      if (indexOfAnyFormat === -1) {
+        plugInErrors.push(new PluginError(PLUGIN_NAME, 'URI is missing or incorrect! Please ' +
+          'use one of ' + ACCEPTABLE_URI_FORMATS));
 
-    // If the type is the index value in the range of files
-    var selectedType = indexOfIndexOf <= 1 ? "file" : "url";
-    console.log(indexOfIndexOf);
-
-    // If provided by the user using the options and not the stream, verify if the file exists first
-    if (selectedType === "file" && !opt.uriFromStream) {
-      try {
-        fs.statSync(opt.uri);
-
-      } catch (FileNotFoundError) {
-	 console.log(FileNotFoundError);
-        stream.emit("error", new PluginError(PLUGIN_NAME, "File path " + opt.uri + " not found!"));
+      } else {
+        // If the type is the index value in the range of files
+        selectedType = indexOfAnyFormat <= 1 ? 'file' : 'url';
       }
     }
 
-    // Open the file with the default app in the OS
-    if (!opt.app) {
-      log(colors.blue('Opening the', selectedType, colors.green(opt.uri), 'using the', colors.green('default OS app')));
-      open(opt.uri);
-
-    } else {
-      log(colors.blue('Opening the', selectedType, colors.green(opt.uri), 'using the app', colors.green(opt.app)));
+    if (opt.app) {
+      log(colors.blue('Opening the', selectedType, colors.green(opt.uri), 'using the app',
+        colors.green(opt.app)));
+      // Open with the given app
       open(opt.uri, opt.app);
+ 
+    } else {
+     log(colors.blue('Opening the', selectedType, colors.green(opt.uri), 'using the',
+        colors.green('default OS app')));
+     // Open with the default app defined by the os
+     open(opt.uri);
     }
-  };
-
-  function done() {
-    // End the stream if it exists
-    if (stream) {
-      stream.emit('end');
-    }
-  }
-
-  // Handles opening the file through the stream
-  var queueFile = function(file) {
-    console.log(file);
-    // Just get the path and inject it to the options to be processed.
-    opt.uri = file.path;
-    opt.uriFromStream = true;
-  };
-
-  // Open the object, whatever that is.
-  var endStream = function() {
-    executeOpening();
-  };
-
-  // copied from gulp-karma
-  stream = es.through(queueFile, endStream);
-
-  return stream;
-}
+  });
+};
 
 /**
  * In addition to the regular path
- * > _followsFormat("github.com")   > _followsFormat("http://github.com")
+ * > _followsFormat('github.com')   > _followsFormat('http://github.com')
  * false                            true
- * > _followsFormat("file://dsdsd") > _followsFormat("/usr/bin") 
+ * > _followsFormat('file://dsdsd') > _followsFormat('/usr/bin') 
  * true                             true
  *
  * @return The index of which type of the acceptable types the uri is from.
  */
-function _indexOfIndexOf(uri) {
+function _getIndexesOfAcceptableFormats(uri) {
   return ACCEPTABLE_URI_FORMATS.map(function(formatPrefix) {
     return uri.indexOf(formatPrefix) === 0;
 
@@ -100,5 +80,3 @@ function _indexOfIndexOf(uri) {
     return value ? index : acc;
   }, false);
 }
-
-module.exports = gulpOpen;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-open",
   "description": "Open files and URLs with gulp",
-  "version": "1.0.0",
+  "version": "0.3.2",
   "homepage": "http://github.com/stevelacy/gulp-open",
   "repository": {
     "type": "git",
@@ -11,16 +11,19 @@
   "main": "./index.js",
   "dependencies": {
     "colors": "^1.1.2",
-    "event-stream": "^3.3.1",
     "gulp-util": "^3.0.2",
-    "open": "0.0.5"
+    "open": "0.0.5",
+    "through2": "^0.6.3"
   },
   "devDependencies": {
+    "jshint": "latest",
     "mocha": "*",
     "should": "*"
   },
   "scripts": {
-    "test": "mocha --reporter spec"
+    "pretest": "if [ ! -f $PWD/.jshintrc ]; then wget https://raw.githubusercontent.com/stevelacy/gulp-stylus/master/.jshintrc; fi && jshint *.js test/*.js",
+    "test": "mocha --reporter spec",
+    "posttest": "rm .jshintrc"
   },
   "engines": {
     "node": ">= 0.9.0"

--- a/package.json
+++ b/package.json
@@ -21,9 +21,8 @@
     "should": "*"
   },
   "scripts": {
-    "pretest": "if [ ! -f $PWD/.jshintrc ]; then wget https://raw.githubusercontent.com/stevelacy/gulp-stylus/master/.jshintrc; fi && jshint *.js test/*.js",
-    "test": "mocha --reporter spec",
-    "posttest": "rm .jshintrc"
+    "pretest": "jshint *.js test/*.js",
+    "test": "mocha --reporter spec"
   },
   "engines": {
     "node": ">= 0.9.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-open",
   "description": "Open files and URLs with gulp",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "homepage": "http://github.com/stevelacy/gulp-open",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "author": "Steve Lacy <me@slacy.me> (http://slacy.me/)",
   "main": "./index.js",
   "dependencies": {
+    "colors": "^1.1.2",
+    "event-stream": "^3.3.1",
     "gulp-util": "^3.0.2",
-    "open": "0.0.5",
-    "through2": "^0.6.3"
+    "open": "0.0.5"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/main.js
+++ b/test/main.js
@@ -1,19 +1,35 @@
 var gulpopen = require('../');
 var should = require('should');
+var os = require("os");
 require('mocha');
 
 describe('gulp-open', function() {
 
-  it('should open a stream of files with the default application', function(done) {
-    gulpopen("<%= file.path%>", done());
+  var browser = os.platform() === 'linux' ? 'google-chrome' : (
+    os.platform() === 'darwin' ? 'google chrome' : (
+    os.platform() === 'win32' ? 'chrome' : 'firefox'));
+ 
+  describe('opening files', function() {
+    it('should open a stream of files with the default application', function(done) {
+      gulpopen("<%= file.path%>", done());
+    });
+
+    it('should open a stream of files with a defined application', function(done) {
+      gulpopen("<%= file.path%>", {app: browser}, done());
+    });
+
+    it('should open a stream of files with a browser using the options', function(done) {
+      gulpopen({}, {uri: __dirname + "/../package.json", app: browser}, done());
+    });
   });
-  it('should open a stream of files with a defined application', function(done) {
-    gulpopen("<%= file.path%>","google-chrome", done());
-  });
-  it('should open a website in a browser', function(done) {
-    gulpopen({url:"http://localhost:3000"}, done());
-  });
-  it('should open a remote or local file in the default application', function(done) {
-    gulpopen({file:"/var/www/index.html"}, done());
+
+  describe('opening urls', function() {
+    it('should open a website in a browser using the options', function(done) {
+      gulpopen({}, {uri:"http://localhost:3000"}, done());
+    });
+
+    it('should open a website in a browser using chrome or firefox', function(done) {
+     gulpopen({}, {uri:"https://www.google.com", app: browser}, done());
+    });
   });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,7 @@
+'use strict';
+
 var gulpopen = require('../');
-var should = require('should');
-var os = require("os");
+var os = require('os');
 require('mocha');
 
 describe('gulp-open', function() {
@@ -11,25 +12,25 @@ describe('gulp-open', function() {
  
   describe('opening files', function() {
     it('should open a stream of files with the default application', function(done) {
-      gulpopen("<%= file.path%>", done());
+      gulpopen('<%= file.path%>', {}, done());
     });
 
     it('should open a stream of files with a defined application', function(done) {
-      gulpopen("<%= file.path%>", {app: browser}, done());
+      gulpopen('<%= file.path%>', {app: browser}, done());
     });
 
     it('should open a stream of files with a browser using the options', function(done) {
-      gulpopen({}, {uri: __dirname + "/../package.json", app: browser}, done());
+      gulpopen({}, {uri: __dirname + '/../package.json', app: browser}, done());
     });
   });
 
   describe('opening urls', function() {
     it('should open a website in a browser using the options', function(done) {
-      gulpopen({}, {uri:"http://localhost:3000"}, done());
+      gulpopen({}, {uri:'http://localhost:3000'}, done());
     });
 
     it('should open a website in a browser using chrome or firefox', function(done) {
-     gulpopen({}, {uri:"https://www.google.com", app: browser}, done());
+     gulpopen({}, {uri:'https://www.google.com', app: browser}, done());
     });
   });
 });


### PR DESCRIPTION
This pull request is to improve and solve on Issue #15 ... In order to properly work, empty files should be passed to the stream `gulp.src()`. The README and Test cases were updated to reflect this proposal.

API Change
---------

Just changing the plugin to use streams and properly handle different protocols:
* file://
* http://
* https://
* File paths starting with "/"

```js
var withFilePath = {
  uri: process.env.PWD + "/package.json"
};
gulp.src([]).pipe(open(withFilePath));

// Open from the stream and default program
gulp.src("./package.json").pipe(open());

// Open from the stream using the app
var chrome = os.platform() === 'linux' ? 'google-chrome' : (
    os.platform() === 'darwin' ? 'google chrome' : (
    os.platform() === 'win32' ? 'chrome' : 'firefox'));
  gulp.src("./package.json").pipe(open({app: chrome}));
```

Output
-------

The task will show if a file or a URL was opened and if that was with the default or with the given app.

```
[19:04:56] Starting 'open'...
[19:04:56] Finished 'open' after 1.25 ms
[19:05:44] Opening the url http://localhost:3001/?ws=localhost:3001&port=5858 using the default OS app
[19:04:56] Opening the file /home/mdesales/dev/github-intuit/servicesplatform-nodejs/sp-reference-restify/package.json using the default OS app
```

Categorized Test Cases
------

```
$ npm test

> gulp-open@0.3.2 test /home/mdesales/dev/github/gulp-open
> mocha --reporter spec

  gulp-open
    opening files
      ✓ should open a stream of files with the default application
      ✓ should open a stream of files with a defined application
      ✓ should open a stream of files with a browser using the options
    opening urls
      ✓ should open a website in a browser using the options
      ✓ should open a website in a browser using chrome or firefox

  5 passing (5ms)
```