### PR TITLE
Add Note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ NOTE: If the ``options.app`` is not defined, the Default application will be use
 If you have Parallels Desktop installed with the same browser, you might have to use an absolute path:
 
 ```javascript
-var browserOptions = {
+var options = {
   uri: 'localhost:3000',
   app: '/Applications/Google\ Chrome.app'
 };
 gulp.src('./')
-  .pipe( open( browserOptions ) );
+  .pipe( open( options ) );
 ```
 
 ###Options.uri

--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ NOTE: If the ``options.app`` is not defined, the Default application will be use
 .pipe(open({uri: 'file:///etc/resolv.conf', app: 'google-chrome'}));
 
 ```
+
+####Note for OSX-Users:
+If you have Parallels Desktop installed with the same browser, you might have to use an absolute path:
+
+```javascript
+var browserOptions = {
+  uri: 'localhost:3000',
+  app: '/Applications/Google\ Chrome.app'
+};
+gulp.src('./')
+  .pipe( open( browserOptions ) );
+```
+
 ###Options.uri
 `String, any valid uri (url, file protocol, or full path)`
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ NOTE: If the ``options.app`` is not defined, the Default application will be use
 ```
 
 ####Note for OSX-Users:
-If you have Parallels Desktop installed with the same browser, you might have to use an absolute path:
+You might have to use an absolute path.
 
 ```javascript
 var options = {


### PR DESCRIPTION
Add note about absolute paths for `options.app` on OSX with Parallels Desktop installed