### PR TITLE
Switch to `opn`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "iojs"
-  - "0.10"
-  - "0.12"
+  - "8"
+  - "6"
+  - "4"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </tr>
 <tr>
 <td>Node Version</td>
-<td>>= 0.9</td>
+<td>>= 4</td>
 </tr>
 <tr>
 <td>Gulp Version</td>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var open = require('open');
+var open = require('opn');
 var through = require('through2');
 var log = require('plugin-log');
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./index.js",
   "dependencies": {
     "colors": "^1.1.2",
-    "open": "0.0.5",
+    "opn": "5.2.0",
     "plugin-log": "^0.1.0",
     "through2": "^2.0.1"
   },
@@ -25,7 +25,7 @@
     "test": "mocha --reporter spec"
   },
   "engines": {
-    "node": ">= 0.9.0"
+    "node": ">=4"
   },
   "keywords": [
     "gulp",


### PR DESCRIPTION
Closes #30.

Notice that this is a breaking change. `opn` doesn't support node < 4.